### PR TITLE
255_256_SRGAN - Conditionally set he image data format to channels_last

### DIFF
--- a/255_256_SRGAN/SRGAN_train.py
+++ b/255_256_SRGAN/SRGAN_train.py
@@ -27,6 +27,9 @@ from keras.layers import Conv2D, PReLU,BatchNormalization, Flatten
 from keras.layers import UpSampling2D, LeakyReLU, Dense, Input, add
 from tqdm import tqdm
 
+# some versions of Tf.keras will need you to configure channels last to make this notebook work
+# keras.backend.set_image_data_format('channels_last')
+
 #########################################################################
 
 #Define blocks to build the generator


### PR DESCRIPTION
On my configuration with versions:

```
TF version: 2.10.0
Keras version: 2.10.0
```

I had to make this simple change in order to have this notebook work. Otherwise, creating the VGG19 model would fail indicating that the channel was incorrectly positioned.

I would even argue that perhaps this configuration should not be commented, but I'll leave it to you to decide. Let me know if I should change.