### PR TITLE
Update 288_nuclei_tracking_trackpy_stardist.ipynb

### DIFF
--- a/288_nuclei_tracking_trackpy_stardist.ipynb
+++ b/288_nuclei_tracking_trackpy_stardist.ipynb
@@ -1141,11 +1141,11 @@
         "for num, img in enumerate(my_fl_img):\n",
         "    for region in skimage.measure.regionprops(label_image[num], intensity_image=img):\n",
         "        # Store features \n",
-        "        features = features.append([{'y': region.centroid[0],\n",
+        "        features = features.conact([{'y': region.centroid[0],\n",
         "                                     'x': region.centroid[1],\n",
         "                                     'frame': num,\n",
         "                                     'area': region.area,\n",
-        "                                     },])"
+        "                                     },], ignore_index=True)"
       ],
       "metadata": {
         "id": "uyifUyiHtwKl"


### PR DESCRIPTION
From pandas 2.0, append (previously deprecated) was removed. This change suggests using concat instead.

Pandas documentation:
https://pandas.pydata.org/docs/whatsnew/v2.0.0.html#removal-of-prior-version-deprecations-changes