### PR TITLE
Expand dimension of patched training image

### DIFF
--- a/331_fine_tune_SAM_mito.ipynb
+++ b/331_fine_tune_SAM_mito.ipynb
@@ -186,6 +186,7 @@
         "        for j in range(patches_img.shape[1]):\n",
         "\n",
         "            single_patch_img = patches_img[i,j,:,:]\n",
+        "            single_patch_img = np.stack((single_patch_img,) * 3, axis=-1)\n",
         "            all_img_patches.append(single_patch_img)\n",
         "\n",
         "images = np.array(all_img_patches)\n",


### PR DESCRIPTION
Without expanding dimension the following error comes up in while executing code block 33: example = train_dataset[0]
for k,v in example.items():
  print(k,v.shape)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-18-ee9fee6be012> in <cell line: 1>()
----> 1 example = train_dataset[0]
      2 for k,v in example.items():
      3   print(k,v.shape)

6 frames
/usr/local/lib/python3.10/dist-packages/transformers/image_utils.py in infer_channel_dimension_format(image, num_channels)
    198         first_dim, last_dim = 1, 3
    199     else:
--> 200         raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
    201 
    202     if image.shape[first_dim] in num_channels:

ValueError: Unsupported number of image dimensions: 2