### PR TITLE
expanding dimension to solve the dimension incompatibility

### DIFF
--- a/331_fine_tune_SAM_mito.ipynb
+++ b/331_fine_tune_SAM_mito.ipynb
@@ -1064,6 +1064,7 @@
         "large_test_images = tifffile.imread(\"/content/drive/MyDrive/ColabNotebooks/data/mitochondria/small_dataset_for_training/images/12_training_mito_images.tif\")\n",
         "large_test_image = large_test_images[1]\n",
         "patches = patchify(large_test_image, (256, 256), step=256)  #Step=256 for 256 patches means no overlap\n"
+        "patches = np.stack((patches,) * 3, axis=-1)  #expanding dimension \n"
       ],
       "metadata": {
         "id": "VN3AXZpTAW85"


### PR DESCRIPTION
Solving value error in code block 55:

---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-55-9020ca8664fe> in <cell line: 25>()
     23 #inputs = processor(single_patch, return_tensors="pt")
     24 #Now try with bounding boxes. Remember to uncomment.
---> 25 inputs = processor(single_patch, input_points=input_points, return_tensors="pt")
     26 
     27 # Move the input tensor to the GPU if it's not already there

5 frames
/usr/local/lib/python3.10/dist-packages/transformers/image_utils.py in infer_channel_dimension_format(image, num_channels)
    198         first_dim, last_dim = 1, 3
    199     else:
--> 200         raise ValueError(f"Unsupported number of image dimensions: {image.ndim}")
    201 
    202     if image.shape[first_dim] in num_channels:

ValueError: Unsupported number of image dimensions: 2